### PR TITLE
Add webdriver property

### DIFF
--- a/src/properties.ts
+++ b/src/properties.ts
@@ -2,7 +2,8 @@ export type ClientProperties = {
   languages: readonly string[]
   plugins: string[]
   custom_window: string[]
-  // TODO: Add more checks: window size, navigator properties, webdriver, etc. ...
+  webdriver: boolean
+  // TODO: Add more checks: window size, navigator properties, etc. ...
 }
 
 // TODO/Brainstorm: Think about required custom properties
@@ -78,11 +79,19 @@ class Properties {
     return navigator.languages;
   }
 
+  /**
+   * Return value of webdriver property.
+   */
+  getWebdriver(): boolean {
+    return navigator.webdriver;
+  }
+
   collect(): ClientProperties {
     return {
       languages: this.getLanguages(),
       plugins: this.getPlugins(),
       custom_window: this.getWindowCustomProperties(),
+      webdriver: this.getWebdriver(),
     };
   }
 }


### PR DESCRIPTION
> In order to automate Chrome headless, a new property webdriver is added to the navigator object. Thus, by testing if the property is present it is possible to detect Chrome headless.

Goes with: https://github.com/antibot-dev-team/antibot-backend/pull/6